### PR TITLE
Creating Temporary Tables in a SELECT Statement Without a Separate CREATE TABLE

### DIFF
--- a/sql-queries-4/temporary-table-select/extract_data_into_temp.sql
+++ b/sql-queries-4/temporary-table-select/extract_data_into_temp.sql
@@ -1,0 +1,7 @@
+SELECT * 
+FROM ( 
+	SELECT id, name, textbook, credits 
+	FROM Course 
+	WHERE is_active = 'No' 
+) 
+AS Temp_table;

--- a/sql-queries-4/temporary-table-select/extract_data_into_temp_sqlserver.sql
+++ b/sql-queries-4/temporary-table-select/extract_data_into_temp_sqlserver.sql
@@ -1,0 +1,5 @@
+SELECT id, name, textbook, credits 
+INTO #Inactive_courses 
+FROM Course 
+WHERE is_active = 'No'; 
+SELECT * FROM #Inactive_courses;

--- a/sql-queries-4/temporary-table-select/temp_with_join_statement.sql
+++ b/sql-queries-4/temporary-table-select/temp_with_join_statement.sql
@@ -1,0 +1,7 @@
+SELECT * 
+FROM ( 
+	SELECT id, name, textbook, credits 
+	FROM Course 
+	WHERE is_active = 'No' 
+) AS Temp_table 
+JOIN Teaching ON Temp_table.id = Teaching.course_id;

--- a/sql-queries-4/temporary-table-select/temp_with_join_statement_SQLserver.sql
+++ b/sql-queries-4/temporary-table-select/temp_with_join_statement_SQLserver.sql
@@ -1,0 +1,8 @@
+SELECT id, name, textbook, credits 
+INTO #Inactive_courses 
+FROM Course 
+WHERE is_active = 'No'; 
+
+SELECT * 
+FROM #Inactive_courses 
+JOIN Teaching ON #Inactive_courses.id = Teaching.course_id;

--- a/sql-queries-4/temporary-table-select/using_AS_Syn.sql
+++ b/sql-queries-4/temporary-table-select/using_AS_Syn.sql
@@ -1,0 +1,5 @@
+SELECT * 
+FROM ( 
+       SELECT column1, column2 FROM Existing_table WHERE condition 
+) 
+AS Temp_table;

--- a/sql-queries-4/temporary-table-select/using_AltSyn_SqlServer.sql
+++ b/sql-queries-4/temporary-table-select/using_AltSyn_SqlServer.sql
@@ -1,4 +1,4 @@
-SELECT column1, column2, ... 
+SELECT column1, column2 
 INTO #Temporary_table 
 FROM Source_table 
 WHERE condition;

--- a/sql-queries-4/temporary-table-select/using_AltSyn_SqlServer.sql
+++ b/sql-queries-4/temporary-table-select/using_AltSyn_SqlServer.sql
@@ -1,0 +1,4 @@
+SELECT column1, column2, ... 
+INTO #Temporary_table 
+FROM Source_table 
+WHERE condition;


### PR DESCRIPTION
Creating Temporary Tables in a SELECT Statement Without a Separate CREATE TABLE