### PR TITLE
Add update-using-select folder with three SQL Server update methods

### DIFF
--- a/updating/update-using-select/update-using-select-via-join-sqlserver.sql
+++ b/updating/update-using-select/update-using-select-via-join-sqlserver.sql
@@ -1,0 +1,9 @@
+-- Method 2: Update via JOIN
+UPDATE Course
+SET is_active = 
+    CASE WHEN Department.code = 'EC' THEN 'Yes' ELSE 'No' END
+FROM Course
+JOIN Department ON Course.department_id = Department.id;
+
+-- View result
+SELECT * FROM Course;

--- a/updating/update-using-select/update-using-select-via-merge-sqlserver.sql
+++ b/updating/update-using-select/update-using-select-via-merge-sqlserver.sql
@@ -1,0 +1,12 @@
+-- Method 3: Update via MERGE
+MERGE Course AS Target
+USING (
+    SELECT id, code FROM Department
+) AS Source
+ON Target.department_id = Source.id
+WHEN MATCHED THEN
+    UPDATE SET Target.is_active =
+        CASE 
+            WHEN Source.code = 'ME' THEN 'Yes'
+            ELSE 'No'
+        END;

--- a/updating/update-using-select/update-using-select-via-subquery-sqlserver.sql
+++ b/updating/update-using-select/update-using-select-via-subquery-sqlserver.sql
@@ -1,0 +1,13 @@
+-- Method 1: Update via Subquery
+UPDATE Course
+SET is_active = (
+    SELECT CASE 
+        WHEN Department.code = 'CS' THEN 'Yes'
+        ELSE 'No'
+    END
+    FROM Department
+    WHERE Department.id = Course.department_id
+);
+
+-- View result
+SELECT * FROM Course;


### PR DESCRIPTION
The codes for the article SQL SQL-86
 "How to UPDATE a Record using a SELECT in SQL Server"
This PR adds a new folder `update-using-select` under the `updating` directory, containing:

- update-using-subquery.sql
- update-using-join.sql
- update-using-merge.sql